### PR TITLE
Torbutton expects failure rather than fail

### DIFF
--- a/public/torbutton.html
+++ b/public/torbutton.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
 <body>
-  <a id="TorCheckResult" target="{{ if .IsTor }}success{{ else }}fail{{ end }}" href="/"></a>
+  <a id="TorCheckResult" target="{{ if .IsTor }}success{{ else }}failure{{ end }}" href="/"></a>
 </body>
 </html>


### PR DESCRIPTION
Shouldn't change anything since Torbutton will fallback to failure due to 'Strange target', but it would be better to match expected value for better error messages on client.
See: https://gitweb.torproject.org/torbutton.git/blob/HEAD:/src/components/torCheckService.js#l113
