### PR TITLE
It's Tor Browser now, not Tor Browser Bundle.

### DIFF
--- a/check.pot
+++ b/check.pot
@@ -22,7 +22,7 @@ msgid ""
 "the Internet anonymously."
 msgstr ""
 
-msgid "There is a security update available for the Tor Browser Bundle."
+msgid "There is a security update available for Tor Browser."
 msgstr ""
 
 msgid ""
@@ -89,7 +89,7 @@ msgstr ""
 msgid "JavaScript is disabled."
 msgstr ""
 
-msgid "However, it does not appear to be the Tor Browser Bundle."
+msgid "However, it does not appear to be Tor Browser."
 msgstr ""
 
 msgid "Run a Relay"

--- a/public/index.html
+++ b/public/index.html
@@ -81,13 +81,13 @@
   {{ if .IsTor }}
       {{ if .NotUpToDate }}
         <p class="security">
-          {{ GetText .Lang "There is a security update available for the Tor Browser Bundle." }}<br />
+          {{ GetText .Lang "There is a security update available for Tor Browser." }}<br />
           {{ GetText .Lang "<a href=\"https://www.torproject.org/download/download-easy.html\">Click here to go to the download page</a>" | UnEscaped }}
         </p>
       {{ else }}
         {{ if .NotTBB }}
           <p class="security">
-            {{ GetText .Lang "However, it does not appear to be the Tor Browser Bundle." }}<br />
+            {{ GetText .Lang "However, it does not appear to be Tor Browser." }}<br />
             {{ GetText .Lang "<a href=\"https://www.torproject.org/download/download-easy.html\">Click here to go to the download page</a>" | UnEscaped }}
           </p>
         {{ end }}


### PR DESCRIPTION
Hi Arlo--
We're trying to get people saying "Tor Browser" instead of "Tor Browser Bundle" as part of https://trac.torproject.org/projects/tor/ticket/11193 , so I've done a simple replace on the user-facing strings.
